### PR TITLE
Added missing permissions

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -43,7 +43,9 @@
     "device-storage:sdcard": {
       "access": "readwrite",
       "description": "Required to read and write podcasts episodes to external storage."
-    }
+    },
+    "spatialnavigation-app-manage": {},
+    "serviceworker": {}
   },
   "default_locale": "en",
   "cursor": false


### PR DESCRIPTION
Especially the "spatialnavigation-app-manage" permission, which was missing so the cursor wouldn't appear on login even though `navigator.spatialNavigationEnabled` was set to `true`.